### PR TITLE
Build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,14 @@
             </snapshots>
         </repository>
         <repository>
+            <id>spring-snapshots-continuous</id>
+            <name>Spring Snapshots Continuous</name>
+            <url>http://repo.spring.io/libs-snapshot-continuous-local</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
             <url>http://repo.spring.io/libs-milestone-local</url>


### PR DESCRIPTION
With the current configuration the project does not build, because the dependency 
`org.springframework.data:spring-data-neo4j:3.4.0.BUILD_SNAPSHOT`
is not located in the `libs-snapshot-local` repository

However the dependency can be resolved by adding the `libs-snapshot-continuous-local` repository to the list.
This is what the PR does