### PR TITLE
hystrix setup for avoid timeout

### DIFF
--- a/api-gateway-microservice/src/main/resources/application.yml
+++ b/api-gateway-microservice/src/main/resources/application.yml
@@ -20,3 +20,11 @@ eureka:
     fetchRegistry: true
     serviceUrl:
       defaultZone: http://discovery:8761/eureka/
+
+hystrix:
+  command:
+    default:
+      execution:
+        isolation:
+          thread:
+            timeoutInMilliseconds: 30000      


### PR DESCRIPTION
I downloaded the application today and found it exception when load the movie microservice.

com.netflix.zuul.exception.ZuulException: Forwarding error

Investigate about this topic and found it error reported

https://github.com/spring-cloud/spring-cloud-netflix/issues/1417

The solution was setup the hystrix timeout in the application.yml

José Díaz
PERU JUG

